### PR TITLE
[refs #114] Rename flag objects reverse modifier

### DIFF
--- a/objects/_objects.flag.scss
+++ b/objects/_objects.flag.scss
@@ -85,7 +85,7 @@
     padding-right: $inuit-global-spacing-unit-tiny;
   }
 
-  &.o-flag--rev {
+  &.o-flag--reverse {
 
     > .o-flag__img {
       padding-right: 0;
@@ -102,7 +102,7 @@
     padding-right: $inuit-global-spacing-unit-small;
   }
 
-  &.o-flag--rev {
+  &.o-flag--reverse {
 
     > .o-flag__img {
       padding-right: 0;
@@ -119,7 +119,7 @@
     padding-right: $inuit-global-spacing-unit-large;
   }
 
-  &.o-flag--rev {
+  &.o-flag--reverse {
 
     > .o-flag__img {
       padding-right: 0;
@@ -136,7 +136,7 @@
     padding-right: $inuit-global-spacing-unit-huge;
   }
 
-  &.o-flag--rev {
+  &.o-flag--reverse {
 
     > .o-flag__img {
       padding-right: 0;
@@ -169,7 +169,7 @@
  * 3. Reassign margins to the correct sides.
  */
 
-.o-flag--rev {
+.o-flag--reverse {
   direction: rtl; /* [1] */
 
   > .o-flag__img,


### PR DESCRIPTION
The reverse modifiers of the media object and layout object
were named `--reverse`. The appropriate modifier of the flag
object was named `--rev`. Aligning the naming seemed like a
good idea, so the flag object modifier was renamed to
`.o-flag--reverse`.