### PR TITLE
Highlight available functionality in [utilities.widths]

### DIFF
--- a/example.main.scss
+++ b/example.main.scss
@@ -146,6 +146,8 @@
 
 // UTILITIES
 @import "utilities/utilities.clearfix";
+
+$inuit-offsets: true;
 @import "utilities/utilities.widths";
 @import "utilities/utilities.headings";
 @import "utilities/utilities.spacing";

--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -2,10 +2,45 @@
    #WIDTHS
    ========================================================================== */
 
+/**
+ * inuitcss generates a series of utility classes that give a fluid width to
+ * whichever element they’re applied, e.g.:
+ *
+ *   <img src="" alt="" class="u-1/2" />
+ *
+ * These classes are most commonly used in conjunction with our layout system,
+ * e.g.:
+ *
+ *   <div class="o-layout__item  u-1/2">
+ *
+ * By default, inuitcss will also generate responsive variants of each of these
+ * classes by using your Sass MQ configuration, e.g.:
+ *
+ *   <div class="o-layout__item  u-1/1  u-1/2@tablet  u-1/3@desktop">
+ *
+ * Optionally, inuitcss can generate offset classes which can push and pull
+ * elements left and right by a specified amount, e.g.:
+ *
+ *   <div class="o-layout__item  u-2/3  u-pull-1/3">
+ *
+ * This is useful for making very granular changes to the rendered order of
+ * items in a layout.
+ *
+ * N.B. This option is turned off by default.
+ */
+
+
+
+
+
 // Which fractions would you like in your grid system(s)? By default, inuitcss
-// provides you fractions of one whole (1/1), halves (1/2, 2/2), thirds (1/3,
-// 2/3, 3/3), quarters (1/4, 2/4, 3/4, 4/4) and fifths (1/5, 2/5, 3/5, 4/5,
-// 5/5).
+// provides you fractions of one whole, halves, thirds, quarters and fifths,
+// e.g.:
+//
+//   .u-1/2
+//   .u-2/5
+//   .u-3/4
+//   .u-2/3
 
 $inuit-fractions: 1 2 3 4 5 !default;
 
@@ -14,7 +49,12 @@ $inuit-fractions: 1 2 3 4 5 !default;
 
 
 // Optionally, inuitcss can generate classes to offset items by a certain width.
-// Would you like to generate these types of class as well?
+// Would you like to generate these types of class as well? E.g.:
+//
+//   .u-push-1/3
+//   .u-pull-2/4
+//   .u-pull-1/5
+//   .u-push-2/3
 
 $inuit-offsets: false !default;
 

--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -6,7 +6,17 @@
 // provides you fractions of one whole (1/1), halves (1/2, 2/2), thirds (1/3,
 // 2/3, 3/3), quarters (1/4, 2/4, 3/4, 4/4) and fifths (1/5, 2/5, 3/5, 4/5,
 // 5/5).
+
 $inuit-fractions: 1 2 3 4 5 !default;
+
+
+
+
+
+// Optionally, inuitcss can generate classes to offset items by a certain width.
+// Would you like to generate these types of class as well?
+
+$inuit-offsets: false !default;
 
 
 
@@ -32,22 +42,26 @@ $inuit-fractions: 1 2 3 4 5 !default;
         width: ($numerator / $denominator) * 100% !important;
       }
 
-      /**
-       * 1. Defensively reset any leftover or conflicting `left`/`right` values.
-       */
+      @if ($inuit-offsets == true) {
 
-      // Build a class in the format `.u-push-1/2[@<breakpoint>]`.
-      .u-push-#{$numerator}\/#{$denominator}#{$breakpoint} {
-        position: relative;
-        right: auto; /* [1] */
-        left: ($numerator / $denominator) * 100% !important;
-      }
+        /**
+        * 1. Defensively reset any leftover or conflicting `left`/`right` values.
+        */
 
-      // Build a class in the format `.u-pull-5/6[@<breakpoint>]`.
-      .u-pull-#{$numerator}\/#{$denominator}#{$breakpoint} {
-        position: relative;
-        right: ($numerator / $denominator) * 100% !important;
-        left: auto; /* [1] */
+        // Build a class in the format `.u-push-1/2[@<breakpoint>]`.
+        .u-push-#{$numerator}\/#{$denominator}#{$breakpoint} {
+          position: relative;
+          right: auto; /* [1] */
+          left: ($numerator / $denominator) * 100% !important;
+        }
+
+        // Build a class in the format `.u-pull-5/6[@<breakpoint>]`.
+        .u-pull-#{$numerator}\/#{$denominator}#{$breakpoint} {
+          position: relative;
+          right: ($numerator / $denominator) * 100% !important;
+          left: auto; /* [1] */
+        }
+
       }
 
     }


### PR DESCRIPTION
This PR

1. makes it more apparent that we have offset classes in inuitcss and,
2. puts the offset classes behind a feature switch so that we’re not generating too much CSS by default.