### PR TITLE
[refs #0135] Add circle.yml for CI testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ example.html
 *.gz
 node_modules/
 bower_components/
+test/*.css
+.sass-cache

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  node:
+    version: 4.4.7
+  ruby:
+    version: 2.3.1
+dependencies:
+  pre:
+    - npm install npm -g
+    - gem install sass true
+    - npm install
+test:
+  override:
+    - sass example.main.scss test/example.main.css --sourcemap=none
+    - true-cli test/tests.scss
+    - node-sass example.main.scss -o test/
+    - npm test

--- a/test/tests.scss
+++ b/test/tests.scss
@@ -1,0 +1,15 @@
+/* ==========================================================================
+   INUITCSS Ruby Main Test File
+   ========================================================================== */
+
+/**
+ * To run Ruby Sass Tests, we need to import all the test spec files here
+ */
+
+@import 'true';
+
+@import '_tools.font-size.scss';
+@import '_tools.rem.scss';
+@import '_utilities.widths.scss';
+
+@include report();

--- a/test/true.yml
+++ b/test/true.yml
@@ -1,0 +1,2 @@
+options:
+  color: true


### PR DESCRIPTION
This would add CircleCI integration. If we choose Travis over Circle, it shouldn’t differ too much from it.

One question remains here: Do we want to run tests against ruby-sass or libsass? I’m not sure but maybe we can also run them against both?

@inuitcss/core + @tymondesigns  