### PR TITLE
[refs #181] Fix duplicate key error in ratio and crop objects

### DIFF
--- a/objects/_objects.crop.scss
+++ b/objects/_objects.crop.scss
@@ -5,9 +5,9 @@
 // A list of cropping ratios that get generated as modifier classes.
 
 $inuit-crops: (
-  2:1,
-  4:3,
-  16:9,
+  (2:1),
+  (4:3),
+  (16:9),
 ) !default;
 
 
@@ -76,18 +76,22 @@ $inuit-crops: (
  *
  */
 
-@each $antecedent, $consequent in $inuit-crops {
+@each $crop in $inuit-crops {
 
-  @if (type-of($antecedent) != number) {
-    @error "`#{$antecedent}` needs to be a number."
-  }
+  @each $antecedent, $consequent in $crop {
 
-  @if (type-of($consequent) != number) {
-    @error "`#{$consequent}` needs to be a number."
-  }
+    @if (type-of($antecedent) != number) {
+      @error "`#{$antecedent}` needs to be a number."
+    }
 
-  .o-crop--#{$antecedent}\:#{$consequent} {
-    padding-bottom: ($consequent/$antecedent) * 100%;
+    @if (type-of($consequent) != number) {
+      @error "`#{$consequent}` needs to be a number."
+    }
+
+    .o-crop--#{$antecedent}\:#{$consequent} {
+      padding-bottom: ($consequent/$antecedent) * 100%;
+    }
+
   }
 
 }

--- a/objects/_objects.ratio.scss
+++ b/objects/_objects.ratio.scss
@@ -5,9 +5,9 @@
 // A list of aspect ratios that get generated as modifier classes.
 
 $inuit-ratios: (
-  2:1,
-  4:3,
-  16:9,
+  (2:1),
+  (4:3),
+  (16:9),
 ) !default;
 
 
@@ -62,18 +62,22 @@ $inuit-ratios: (
  *
  */
 
-@each $antecedent, $consequent in $inuit-ratios {
+@each $ratio in $inuit-ratios {
 
-  @if (type-of($antecedent) != number) {
-    @error "`#{$antecedent}` needs to be a number."
-  }
+  @each $antecedent, $consequent in $ratio {
 
-  @if (type-of($consequent) != number) {
-    @error "`#{$consequent}` needs to be a number."
-  }
+    @if (type-of($antecedent) != number) {
+      @error "`#{$antecedent}` needs to be a number."
+    }
 
-  .o-ratio--#{$antecedent}\:#{$consequent}:before {
-    padding-bottom: ($consequent/$antecedent) * 100%;
+    @if (type-of($consequent) != number) {
+      @error "`#{$consequent}` needs to be a number."
+    }
+
+    .o-ratio--#{$antecedent}\:#{$consequent}:before {
+      padding-bottom: ($consequent/$antecedent) * 100%;
+    }
+
   }
 
 }


### PR DESCRIPTION
Avoid duplicated key sass errors when adding more ratios with the same `$antecedent`. It could be solved by using lists, but with this we can keep the nice `x:y` template sintax in `$inuit-ratios` and `$inuit-crops`, only adding parentheses to the original map.