### PR TITLE
[utilities.spacing] Make spacing classes configurable

### DIFF
--- a/utilities/_utilities.spacing.scss
+++ b/utilities/_utilities.spacing.scss
@@ -16,17 +16,17 @@
 /* stylelint-disable string-quotes */
 
 $inuit-spacing-directions: (
-  null,
-  '-top',
-  '-right',
-  '-bottom',
-  '-left',
-);
+  null: null,
+  '-top': '-top',
+  '-right': '-right',
+  '-bottom': '-bottom',
+  '-left': '-left',
+) !default;
 
 $inuit-spacing-properties: (
-  'padding',
-  'margin'
-);
+  'padding': 'padding',
+  'margin': 'margin',
+) !default;
 
 $inuit-spacing-sizes: (
   null: $inuit-global-spacing-unit,
@@ -38,13 +38,13 @@ $inuit-spacing-sizes: (
 ) !default;
 
 
-@each $property in $inuit-spacing-properties {
+@each $property, $property-namespace in $inuit-spacing-properties {
 
-  @each $direction in $inuit-spacing-directions {
+  @each $direction, $direction-namespace in $inuit-spacing-directions {
 
     @each $size, $value in $inuit-spacing-sizes {
 
-      .u-#{$property}#{$direction}#{$size} {
+      .u-#{$property-namespace}#{$direction-namespace}#{$size} {
         #{$property}#{$direction}: $value !important;
       }
 


### PR DESCRIPTION
As discussed in #159, this change would make the spacing classes configurable, so anyone can customize e.g. the following class

```scss
.u-margin-bottom-large
```

to e.g.

```scss
.u-mb+
```

or whatever they fancy.