### PR TITLE
[utilities.widths] Make widths-delimiter and breakpoint-separator configurable

### DIFF
--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -62,6 +62,24 @@ $inuit-offsets: false !default;
 
 
 
+// By default, inuitcss uses fractions-like classes like `<div class="u-1/4">`.
+// You can change the `/` to whatever you fancy with this variable.
+$inuit-widths-delimiter: \/ !default;
+
+
+
+
+
+// When using Sass-MQ, this defines the separator for the breakpoints suffix
+// in the class name. By default, we are generating the responsive suffixes
+// for the classes with a `@` symbol so you get classes like:
+// <div class="u-3/12@mobile">
+$inuit-widths-breakpoint-separator: \@ !default;
+
+
+
+
+
 // A mixin to spit out our width classes. Pass in the columns we want the widths
 // to have, and an optional suffix for responsive widths. E.g. to create thirds
 // and quarters for a small breakpoint:
@@ -78,7 +96,7 @@ $inuit-offsets: false !default;
     @for $numerator from 1 through $denominator {
 
       // Build a class in the format `.u-3/4[@<breakpoint>]`.
-      .u-#{$numerator}\/#{$denominator}#{$breakpoint} {
+      .u-#{$numerator}#{$inuit-widths-delimiter}#{$denominator}#{$breakpoint} {
         width: ($numerator / $denominator) * 100% !important;
       }
 
@@ -89,14 +107,14 @@ $inuit-offsets: false !default;
         */
 
         // Build a class in the format `.u-push-1/2[@<breakpoint>]`.
-        .u-push-#{$numerator}\/#{$denominator}#{$breakpoint} {
+        .u-push-#{$numerator}#{$inuit-widths-delimiter}#{$denominator}#{$breakpoint} {
           position: relative;
           right: auto; /* [1] */
           left: ($numerator / $denominator) * 100% !important;
         }
 
         // Build a class in the format `.u-pull-5/6[@<breakpoint>]`.
-        .u-pull-#{$numerator}\/#{$denominator}#{$breakpoint} {
+        .u-pull-#{$numerator}#{$inuit-widths-delimiter}#{$denominator}#{$breakpoint} {
           position: relative;
           right: ($numerator / $denominator) * 100% !important;
           left: auto; /* [1] */
@@ -141,7 +159,7 @@ $inuit-offsets: false !default;
   @each $inuit-bp-name, $inuit-bp-value in $mq-breakpoints {
 
     @include mq($from: $inuit-bp-name) {
-      @include inuit-widths($inuit-fractions, \@#{$inuit-bp-name});
+      @include inuit-widths($inuit-fractions, #{$inuit-widths-breakpoint-separator}#{$inuit-bp-name});
     }
 
   }


### PR DESCRIPTION
As proposed in #166, this change allows to change the default `/` widths-delimiter to a custom separator, e.g. `-at`. This is useful when using HAML, which considers the `/` as invalid.

Also, the breakpoint-separator can be customized.