### PR TITLE
[refs #190] Display utility classes

### DIFF
--- a/utilities/_utilities.display.scss
+++ b/utilities/_utilities.display.scss
@@ -32,7 +32,9 @@ $inuit-display-values: (
   // Loop through the display values.
   @each $value in $values {
 
-    .u-display-#{$value}#{$breakpoint} { display: $value !important; }
+    .u-display-#{$value}#{$breakpoint} {
+      display: $value !important;
+    }
 
   }
 
@@ -56,7 +58,7 @@ $inuit-display-values: (
 
 
 /**
- * If we’re using Sass-MQ, automatically generate each display class, 
+ * If we’re using Sass-MQ, automatically generate each display class,
  * and give them a Responsive Suffix, e.g.:
  *
  * <div class="u-display-none@mobile">
@@ -64,9 +66,9 @@ $inuit-display-values: (
  */
 
 @if (variable-exists(mq-breakpoints)) {
-  
+
   @each $inuit-bp-name, $inuit-bp-value in $mq-breakpoints {
-    
+
     @include mq($from: $inuit-bp-name) {
 
       @include inuit-displays($inuit-display-values, \@#{$inuit-bp-name});

--- a/utilities/_utilities.display.scss
+++ b/utilities/_utilities.display.scss
@@ -1,0 +1,78 @@
+/* ==========================================================================
+   #DISPLAYS
+   ========================================================================== */
+
+/**
+ * Display helpers, with responsive support.
+ */
+
+
+// inuitcss generates display helper classes. E.g.:
+//
+//   .u-display-block
+//   .u-display-inline-block
+//   .u-display-none
+
+// You can predefine the map bellow to add or remove display values, if needed.
+
+$inuit-display-values: (
+  none,
+  inline,
+  inline-block,
+  block
+) !default;
+
+
+
+
+
+// A mixin to spit out our display classes.
+@mixin inuit-displays($values, $breakpoint: null) {
+
+  // Loop through the display values.
+  @each $value in $values {
+
+    .u-display-#{$value}#{$breakpoint} { display: $value !important; }
+
+  }
+
+}
+
+
+
+
+
+/**
+ * A serie of display helper classes.
+ *
+ * <div class="u-display-block">
+ * <div class="u-display-inline">
+ */
+
+@include inuit-displays($inuit-display-values);
+
+
+
+
+
+/**
+ * If we’re using Sass-MQ, automatically generate each display class, 
+ * and give them a Responsive Suffix, e.g.:
+ *
+ * <div class="u-display-none@mobile">
+ * <div class="u-display-inline-block@desk">
+ */
+
+@if (variable-exists(mq-breakpoints)) {
+  
+  @each $inuit-bp-name, $inuit-bp-value in $mq-breakpoints {
+    
+    @include mq($from: $inuit-bp-name) {
+
+      @include inuit-displays($inuit-display-values, \@#{$inuit-bp-name});
+
+    }
+
+  }
+
+}

--- a/utilities/_utilities.display.scss
+++ b/utilities/_utilities.display.scss
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   #DISPLAYS
+   #DISPLAY
    ========================================================================== */
 
 /**
@@ -13,7 +13,7 @@
 //   .u-display-inline-block
 //   .u-display-none
 
-// You can predefine the map bellow to add or remove display values, if needed.
+// You can predefine the map below to add or remove display values, if needed.
 
 $inuit-display-values: (
   none,
@@ -27,6 +27,7 @@ $inuit-display-values: (
 
 
 // A mixin to spit out our display classes.
+
 @mixin inuit-displays($values, $breakpoint: null) {
 
   // Loop through the display values.
@@ -45,7 +46,7 @@ $inuit-display-values: (
 
 
 /**
- * A serie of display helper classes.
+ * A series of display helper classes.
  *
  * <div class="u-display-block">
  * <div class="u-display-inline">
@@ -62,7 +63,7 @@ $inuit-display-values: (
  * and give them a Responsive Suffix, e.g.:
  *
  * <div class="u-display-none@mobile">
- * <div class="u-display-inline-block@desk">
+ * <div class="u-display-inline-block@desktop">
  */
 
 @if (variable-exists(mq-breakpoints)) {


### PR DESCRIPTION
I simplified @hayatbiralem's suggestion by removing the optional general switch (you can just not import the partial if you don't need it, just like the rest of inuitcss) and the optional aliases feature, which is a little too much complexity for not much value. I also adjusted it to conform to inuitcss' style guide, and edited/added the comments accordingly.

This here should be as simple and css like as this feature can get, and I defended why to add such a feature in the issue.