### PR TITLE
Update `settings.core` 

### DIFF
--- a/settings/_settings.core.scss
+++ b/settings/_settings.core.scss
@@ -41,15 +41,6 @@ $inuit-global-spacing-unit-factor-huge:   4    !default;
 
 
 
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-//                               W A R N I N G                                //
-//                                                                            //
-//                  DO NOT MODIFY ANYTHING BEYOND THIS POINT                  //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-
-
 // Check that the chosen font rules are pixel numbers.
 
 @each $_inuit-font-globals in


### PR DESCRIPTION
This PR merges `tkt-0021` (the tidy-up branch) into `develop`. `tkt-0021` is just one change behind `develop`, but this huge warning block in `settings.core` is quite disturbing and just wrong.

The plan is to merge this in, but of course let the `tkt0021` branch live on after that to commit further tidy-up work against this branch.