### PR TITLE
[refs #217] Provide configurable responsive spacing - off by default

### DIFF
--- a/utilities/_utilities.spacing.scss
+++ b/utilities/_utilities.spacing.scss
@@ -19,47 +19,7 @@
 
 
 
-// Optionally, inuitcss can generate responsive versions of this classes.
-// Would you like to generate these types of class as well? E.g.:
-//
-//   .u-padding-large@desktop
-//   .u-padding-tiny@mobile
-//   .u-margin-huge@tablet
-//   .u-margin-none@wide
-
-$inuit-responsive-spacing: false !default;
-
-
-
-
-
 /* stylelint-disable string-quotes */
-
-// Furthermore, you can choose to generate responsive versions of only
-// a specific set of classes, by predefining this config map:
-
-$inuit-responsive-spacing-config: (
-  properties: 'padding' 'margin',
-  directions: '-top' '-right' '-bottom' '-left' '-horizontal' '-vertical',
-  sizes: null '-tiny' '-small' '-large' '-huge' '-none'
-) !default;
-
-
-
-
-
-// When using Sass-MQ, this defines the separator for the breakpoints suffix
-// in the class name. By default, we are generating the responsive suffixes
-// for the classes with a `@` symbol so you get classes like:
-// 
-// u-padding@mobile
-// u-margin-tiny@desktop
-
-$inuit-spacing-breakpoint-separator: \@ !default;
-
-
-
-
 
 $inuit-spacing-directions: (
   null: null,
@@ -87,6 +47,60 @@ $inuit-spacing-sizes: (
   '-none': 0
 ) !default;
 
+/* stylelint-enable string-quotes */
+
+
+
+
+
+// Optionally, inuitcss can generate responsive versions of this classes.
+// Would you like to generate these types of class as well? E.g.:
+//
+//   .u-padding-large@desktop
+//   .u-padding-tiny@mobile
+//   .u-margin-huge@tablet
+//   .u-margin-none@wide
+
+$inuit-responsive-spacing: false !default;
+
+
+
+
+
+// Furthermore, you can choose to generate responsive versions of only
+// a specific set of classes, by predefining this config with spaces
+// separated lists of namespaces. E.g.:
+//
+// $inuit-responsive-spacing-config : (
+//   properties: 'padding',  
+//   directions: '-horizontal' '-vertical',
+//   sizes: null '-small' '-large' '-none'
+// );
+//
+// Note that the namespaces have to be the same as defined by the keys in: 
+// $inuit-spacing-properties
+// $inuit-spacing-directions
+// $inuit-spacing-sizes
+
+$inuit-responsive-spacing-config: (
+  properties: map-keys($inuit-spacing-properties),
+  directions: map-keys($inuit-spacing-directions),
+  sizes: map-keys($inuit-spacing-sizes)
+) !default;
+
+
+
+
+
+// When using Sass-MQ, this defines the separator for the breakpoints suffix
+// in the class name. By default, we are generating the responsive suffixes
+// for the classes with a `@` symbol so you get classes like:
+// 
+// u-padding@mobile
+// u-margin-tiny@desktop
+
+$inuit-spacing-breakpoint-separator: \@ !default;
+
 
 
 
@@ -100,7 +114,7 @@ $inuit-spacing-sizes: (
 
 @mixin inuit-spacing-properties($properties) {
 
-  @each $property-namespace, $property in $properties {
+  @each $property in $properties {
     @include inuit-spacing-directions($property, $inuit-spacing-directions);
   }
 
@@ -127,30 +141,29 @@ $inuit-spacing-sizes: (
 
 @mixin inuit-spacing-class($property, $direction, $direction-rules, $size, $breakpoint: null) {
 
-  .u-#{$property}#{$direction}#{$size}#{$breakpoint} {
+  $inuit-spacing-property-namespace: nth($property, 1);
+  $inuit-spacing-property-type: nth($property, 2);
 
-    @each $rule in $direction-rules {
-      #{$property}#{$rule}: map-get($inuit-spacing-sizes, $size) !important;
+  .u-#{$inuit-spacing-property-namespace}#{$direction}#{$size}#{$breakpoint} {
+
+    @each $property-rule in $direction-rules {
+      #{$inuit-spacing-property-type}#{$property-rule}: map-get($inuit-spacing-sizes, $size) !important;
     }
 
   }
 
-  $has-responsive: false;
 
-  $responsive-property: index(map-get($inuit-responsive-spacing-config, properties), $property);
-  $responsive-direction: index(map-get($inuit-responsive-spacing-config, directions), $direction);
-  $responsive-size: index(map-get($inuit-responsive-spacing-config, sizes), $size);
+  $inuit-has-responsive-property: index(map-get($inuit-responsive-spacing-config, properties), $inuit-spacing-property-namespace);
+  $inuit-has-responsive-direction: index(map-get($inuit-responsive-spacing-config, directions), $direction);
+  $inuit-has-responsive-size: index(map-get($inuit-responsive-spacing-config, sizes), $size);
 
-  @if ($inuit-responsive-spacing == true and $responsive-property and $responsive-direction and $responsive-size) {
+  @if ($inuit-has-responsive-property and $inuit-has-responsive-direction and $inuit-has-responsive-size) {
 
-    $has-responsive: true;
+    @if (variable-exists(mq-breakpoints) and $inuit-responsive-spacing == true and $breakpoint == null) {
 
-  }
+      @include inuit-spacing-responsive($property, $direction, $direction-rules, $size);
 
-
-  @if (variable-exists(mq-breakpoints) and $breakpoint == null and $has-responsive) {
-
-    @include inuit-spacing-responsive($property, $direction, $direction-rules, $size);
+    }
 
   }
 
@@ -163,7 +176,9 @@ $inuit-spacing-sizes: (
 
     @include mq($from: $inuit-bp-name) {
 
-      @include inuit-spacing-class($property, $direction, $direction-rules, $size, #{$inuit-spacing-breakpoint-separator}#{$inuit-bp-name});
+      $inuit-spacing-breakpoint: #{$inuit-spacing-breakpoint-separator}#{$inuit-bp-name};
+
+      @include inuit-spacing-class($property, $direction, $direction-rules, $size, $inuit-spacing-breakpoint);
 
     }
 
@@ -173,5 +188,3 @@ $inuit-spacing-sizes: (
 
 
 @include inuit-spacing();
-
-/* stylelint-enable string-quotes */

--- a/utilities/_utilities.spacing.scss
+++ b/utilities/_utilities.spacing.scss
@@ -15,6 +15,50 @@
  *   .u-padding-vertical-small {}
  */
 
+
+
+
+
+// Optionally, inuitcss can generate responsive versions of this classes.
+// Would you like to generate these types of class as well? E.g.:
+//
+//   .u-padding-large@desktop
+//   .u-padding-tiny@mobile
+//   .u-margin-huge@tablet
+//   .u-margin-none@wide
+
+$inuit-responsive-spacing: false !default;
+
+
+
+
+
+// Furthermore, you can choose to generate responsive versions of only
+// a specific set of classes, by predefining this config map:
+
+$inuit-responsive-spacing-config : (
+  properties: 'padding' 'margin',
+  directions: '-top' '-right' '-bottom' '-left' '-horizontal' '-vertical',
+  sizes: null '-tiny' '-small' '-large' '-huge' '-none'
+) !default;
+
+
+
+
+
+// When using Sass-MQ, this defines the separator for the breakpoints suffix
+// in the class name. By default, we are generating the responsive suffixes
+// for the classes with a `@` symbol so you get classes like:
+// 
+// u-padding@mobile
+// u-margin-tiny@desktop
+
+$inuit-spacing-breakpoint-separator: \@ !default;
+
+
+
+
+
 /* stylelint-disable string-quotes */
 
 $inuit-spacing-directions: (
@@ -27,10 +71,12 @@ $inuit-spacing-directions: (
   '-vertical': '-top' '-bottom',
 ) !default;
 
+
 $inuit-spacing-properties: (
   'padding': 'padding',
   'margin': 'margin',
 ) !default;
+
 
 $inuit-spacing-sizes: (
   null: $inuit-global-spacing-unit,
@@ -40,6 +86,10 @@ $inuit-spacing-sizes: (
   '-huge': $inuit-global-spacing-unit-huge,
   '-none': 0
 ) !default;
+
+
+
+
 
 @each $property-namespace, $property in $inuit-spacing-properties {
 
@@ -53,6 +103,35 @@ $inuit-spacing-sizes: (
           #{$property}#{$direction}: $size !important;
         }
 
+      }
+
+
+      @if (variable-exists(mq-breakpoints) and $inuit-responsive-spacing == true) {
+        
+        @if (
+          index(map-get($inuit-responsive-spacing-config, properties), $property-namespace) and
+          index(map-get($inuit-responsive-spacing-config, directions), $direction-namespace) and
+          index(map-get($inuit-responsive-spacing-config, sizes), $size-namespace)
+        ) {
+          
+          @each $inuit-bp-name, $inuit-bp-value in $mq-breakpoints {
+      
+            @include mq($from: $inuit-bp-name) {
+              
+              .u-#{$property-namespace}#{$direction-namespace}#{$size-namespace}#{$inuit-spacing-breakpoint-separator}#{$inuit-bp-name} {
+
+                @each $direction in $direction-rules {
+                  #{$property}#{$direction}: $size !important;
+                }
+        
+              }
+              
+            }
+        
+          } 
+          
+        }
+      
       }
 
     }

--- a/utilities/_utilities.spacing.scss
+++ b/utilities/_utilities.spacing.scss
@@ -33,10 +33,12 @@ $inuit-responsive-spacing: false !default;
 
 
 
+/* stylelint-disable string-quotes */
+
 // Furthermore, you can choose to generate responsive versions of only
 // a specific set of classes, by predefining this config map:
 
-$inuit-responsive-spacing-config : (
+$inuit-responsive-spacing-config: (
   properties: 'padding' 'margin',
   directions: '-top' '-right' '-bottom' '-left' '-horizontal' '-vertical',
   sizes: null '-tiny' '-small' '-large' '-huge' '-none'
@@ -58,8 +60,6 @@ $inuit-spacing-breakpoint-separator: \@ !default;
 
 
 
-
-/* stylelint-disable string-quotes */
 
 $inuit-spacing-directions: (
   null: null,
@@ -91,53 +91,87 @@ $inuit-spacing-sizes: (
 
 
 
-@each $property-namespace, $property in $inuit-spacing-properties {
+@mixin inuit-spacing() {
 
-  @each $direction-namespace, $direction-rules in $inuit-spacing-directions {
+  @include inuit-spacing-properties($inuit-spacing-properties);
 
-    @each $size-namespace, $size in $inuit-spacing-sizes {
-
-      .u-#{$property-namespace}#{$direction-namespace}#{$size-namespace} {
-
-        @each $direction in $direction-rules {
-          #{$property}#{$direction}: $size !important;
-        }
-
-      }
+}
 
 
-      @if (variable-exists(mq-breakpoints) and $inuit-responsive-spacing == true) {
-        
-        @if (
-          index(map-get($inuit-responsive-spacing-config, properties), $property-namespace) and
-          index(map-get($inuit-responsive-spacing-config, directions), $direction-namespace) and
-          index(map-get($inuit-responsive-spacing-config, sizes), $size-namespace)
-        ) {
-          
-          @each $inuit-bp-name, $inuit-bp-value in $mq-breakpoints {
-      
-            @include mq($from: $inuit-bp-name) {
-              
-              .u-#{$property-namespace}#{$direction-namespace}#{$size-namespace}#{$inuit-spacing-breakpoint-separator}#{$inuit-bp-name} {
+@mixin inuit-spacing-properties($properties) {
 
-                @each $direction in $direction-rules {
-                  #{$property}#{$direction}: $size !important;
-                }
-        
-              }
-              
-            }
-        
-          } 
-          
-        }
-      
-      }
+  @each $property-namespace, $property in $properties {
+    @include inuit-spacing-directions($property, $inuit-spacing-directions);
+  }
+
+}
+
+
+@mixin inuit-spacing-directions($property, $directions) {
+
+  @each $direction, $direction-rules in $directions {
+    @include inuit-spacing-sizes($property, $direction, $direction-rules, $inuit-spacing-sizes);
+  }
+
+}
+
+
+@mixin inuit-spacing-sizes($property, $direction, $direction-rules, $sizes) {
+
+  @each $size, $size-namespace in $sizes {
+    @include inuit-spacing-class($property, $direction, $direction-rules, $size);
+  }
+
+}
+
+
+@mixin inuit-spacing-class($property, $direction, $direction-rules, $size, $breakpoint: null) {
+
+  .u-#{$property}#{$direction}#{$size}#{$breakpoint} {
+
+    @each $rule in $direction-rules {
+      #{$property}#{$rule}: map-get($inuit-spacing-sizes, $size) !important;
+    }
+
+  }
+
+  $has-responsive: false;
+
+  $responsive-property: index(map-get($inuit-responsive-spacing-config, properties), $property);
+  $responsive-direction: index(map-get($inuit-responsive-spacing-config, directions), $direction);
+  $responsive-size: index(map-get($inuit-responsive-spacing-config, sizes), $size);
+
+  @if ($inuit-responsive-spacing == true and $responsive-property and $responsive-direction and $responsive-size) {
+
+    $has-responsive: true;
+
+  }
+
+
+  @if (variable-exists(mq-breakpoints) and $breakpoint == null and $has-responsive) {
+
+    @include inuit-spacing-responsive($property, $direction, $direction-rules, $size);
+
+  }
+
+}
+
+
+@mixin inuit-spacing-responsive($property, $direction, $direction-rules, $size) {
+
+  @each $inuit-bp-name, $inuit-bp-value in $mq-breakpoints {
+
+    @include mq($from: $inuit-bp-name) {
+
+      @include inuit-spacing-class($property, $direction, $direction-rules, $size, #{$inuit-spacing-breakpoint-separator}#{$inuit-bp-name});
 
     }
 
   }
 
 }
+
+
+@include inuit-spacing();
 
 /* stylelint-enable string-quotes */

--- a/utilities/_utilities.spacing.scss
+++ b/utilities/_utilities.spacing.scss
@@ -21,6 +21,34 @@
 
 /* stylelint-disable string-quotes */
 
+// You can customize the classes inuitcss will generate, by predefining the 
+// next 3 maps. The keys are namespaces, used in the classes names. E.g:
+//
+// The following maps...
+//
+//   $inuit-spacing-directions: (
+//     null: null,
+//     'h': '-left' '-right',
+//     'v': '-top' '-bottom'
+//   );
+// 
+//   $inuit-spacing-properties: (
+//     'p': 'padding'
+//   ) !default;
+// 
+//   $inuit-spacing-sizes: (
+//     null: $inuit-global-spacing-unit,
+//     '-': $inuit-global-spacing-unit-small,
+//     \+: $inuit-global-spacing-unit-large
+//   ) !default;
+//
+// ...would generate only horizontal and vertical padding classes, with only
+// normal, small and large sizes, with this name pattern:
+//
+// .u-p\+ {}
+// .u-pv {}
+// .u-ph- {}
+
 $inuit-spacing-directions: (
   null: null,
   '-top': '-top',
@@ -28,13 +56,13 @@ $inuit-spacing-directions: (
   '-bottom': '-bottom',
   '-left': '-left',
   '-horizontal': '-left' '-right',
-  '-vertical': '-top' '-bottom',
+  '-vertical': '-top' '-bottom'
 ) !default;
 
 
 $inuit-spacing-properties: (
   'padding': 'padding',
-  'margin': 'margin',
+  'margin': 'margin'
 ) !default;
 
 
@@ -105,6 +133,13 @@ $inuit-spacing-breakpoint-separator: \@ !default;
 
 
 
+// The following mixins are called in chain, in order to format and create
+// each of the spacing classes, including responsive versions is the feature
+// was switched on. Each of them extract one aspect of the classes and pass it 
+// to the next step.
+
+// Only for code organization. Start the chain:
+
 @mixin inuit-spacing() {
 
   @include inuit-spacing-properties($inuit-spacing-properties);
@@ -152,6 +187,16 @@ $inuit-spacing-breakpoint-separator: \@ !default;
 
   }
 
+
+  // Here we make some tests to make sure this class should have responsive 
+  // versions:
+  //
+  // 1. If all 3 aspects (property, direction and size) are listed in the 
+  //    $inuit-responsive-spacing-config map;
+  // 2. If Sass-MQ is available;
+  // 3. If the responsive feature switch ($inuit-responsive-spacing) is true;
+  // 4. if the $breakpoint parameter is null, which means the responsive 
+  //    version were not created yet.
 
   $inuit-has-responsive-property: index(map-get($inuit-responsive-spacing-config, properties), $inuit-spacing-property-namespace);
   $inuit-has-responsive-direction: index(map-get($inuit-responsive-spacing-config, directions), $direction);


### PR DESCRIPTION
@csshugs there you go. 

Some points:

1. It's off by default, like with `$inuit-offsets`.
2. Upon turning it on, the default list has all properties, sizes and directions.
3. I applied the same trick from `utilities.widths` regarding the breakpoints separator. I think we should create a `$inuit-global-breakpoint-separator`, but for now I didn't want to mix the issues up. 
4. I could organize the code better with mixins, but it's not really essential.

[DEMO](http://www.sassmeister.com/gist/8d6c0af770f2599f5a94bc8c2c4dc6bc)