### PR TITLE
[refs #254] Reset inherited border-spacings for `.o-flag`

### DIFF
--- a/objects/_objects.flag.scss
+++ b/objects/_objects.flag.scss
@@ -12,11 +12,13 @@
  * 1. Allows us to control vertical alignments.
  * 2. Force the object to be the full width of its parent. Combined with [1],
  *    this makes the object behave in a quasi-`display: block;` manner.
+ * 3. Reset inherited `border-spacing` declarations.
  */
 
 .o-flag {
   display: table; /* [1] */
   width: 100%; /* [2] */
+  border-spacing: 0; /* [3] */
 }
 
 


### PR DESCRIPTION
#254 
Thanks @hayatbiralem for pointing this out! 