### PR TITLE
[refs #245] Add `--left` modifier for `.o-layout`

### DIFF
--- a/objects/_objects.layout.scss
+++ b/objects/_objects.layout.scss
@@ -241,7 +241,6 @@ $inuit-use-markup-fix: false !default;
 
   > .o-layout__item {
     direction: ltr;
-    text-align: left;
   }
 
 }

--- a/objects/_objects.layout.scss
+++ b/objects/_objects.layout.scss
@@ -233,6 +233,21 @@ $inuit-use-markup-fix: false !default;
 
 
 /**
+ * Fill up the layout system from the left-hand side. This will likely only be
+ * needed when using in conjunction with `.o-layout--reverse`.
+ */
+
+.o-layout--left {
+  text-align: left;
+
+  > .o-layout__item {
+    text-align: left;
+  }
+
+}
+
+
+/**
  * Reverse the rendered order of the grid system.
  */
 


### PR DESCRIPTION
#245 

When using `.o-layout--reverse`, there is currently no way to fill up the layout from the left-hand side. By default they are aligned to the right.
By adding the `.o-layout--left` modifier, we now can fill it up from the left-hand side.
