### PR TITLE
[refs #249] Add default-spaced variant for pack object

### DIFF
--- a/objects/_objects.pack.scss
+++ b/objects/_objects.pack.scss
@@ -68,6 +68,10 @@
   border-spacing: $inuit-global-spacing-unit-small;
 }
 
+.o-pack--default {
+  border-spacing: $inuit-global-spacing-unit;
+}
+
 .o-pack--large {
   border-spacing: $inuit-global-spacing-unit-large;
 }


### PR DESCRIPTION
#249 

Currently there is no way to get a pack object with a spacing of `$inuit-global-spacing-unit`. 
This change adds this possibility by providing a `.o-pack--default` modifier class.