### PR TITLE
Fix indents comment block

### DIFF
--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -103,8 +103,8 @@ $inuit-widths-breakpoint-separator: \@ !default;
       @if ($inuit-offsets == true) {
 
         /**
-        * 1. Reset any leftover or conflicting `left`/`right` values.
-        */
+         * 1. Reset any leftover or conflicting `left`/`right` values.
+         */
 
         // Build a class in the format `.u-push-1/2[@<breakpoint>]`.
         .u-push-#{$numerator}#{$inuit-widths-delimiter}#{$denominator}#{$breakpoint} {


### PR DESCRIPTION
Noticed this when vim's color coding did something weird.