### PR TITLE
Add list-bare__item for dl children.

### DIFF
--- a/objects/_objects.list-bare.scss
+++ b/objects/_objects.list-bare.scss
@@ -5,9 +5,17 @@
 /**
  * Strip list-like appearance from lists by removing their bullets, and any
  * indentation.
+ *
+ * Note: Declaring the item-class might not be necessary everywhere but
+ * is for example in <dl> lists for the <dd> childs.
  */
 
 .o-list-bare {
   list-style: none;
   margin-left: 0;
 }
+
+
+  .o-list-bare__item {
+    margin-left: 0;
+  }


### PR DESCRIPTION
This adds a new class `.list-bare__item` for the
list-bare object to ensure that a bare-list can also
be used with `dl`/`dd` HTML element lists.

This fixes #280. 

cc @hatzipanis.