### PR TITLE
[refs #288] Bump normalize.css 5.0.0 to 6.0.0

### DIFF
--- a/generic/_generic.normalize.scss
+++ b/generic/_generic.normalize.scss
@@ -1,32 +1,22 @@
-/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
-
-/**
- * 1. Change the default font family in all browsers (opinionated).
- * 2. Correct the line height in all browsers.
- * 3. Prevent adjustments of font size after orientation changes in
- *    IE on Windows Phone and in iOS.
- */
+/*! normalize.css v6.0.0 | MIT License | github.com/necolas/normalize.css */
 
 /* Document
    ========================================================================== */
 
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
+ */
+
 html {
-  font-family: sans-serif; /* 1 */
-  line-height: 1.15; /* 2 */
-  -ms-text-size-adjust: 100%; /* 3 */
-  -webkit-text-size-adjust: 100%; /* 3 */
+  line-height: 1.15; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections
    ========================================================================== */
-
-/**
- * Remove the margin in all browsers (opinionated).
- */
-
-body {
-  margin: 0;
-}
 
 /**
  * Add the correct display in IE 9-.
@@ -108,17 +98,7 @@ a {
 }
 
 /**
- * Remove the outline on focused links when they are also active or hovered
- * in all browsers (opinionated).
- */
-
-a:active,
-a:hover {
-  outline-width: 0;
-}
-
-/**
- * 1. Remove the bottom border in Firefox 39-.
+ * 1. Remove the bottom border in Chrome 57- and Firefox 39-.
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 
@@ -245,8 +225,7 @@ svg:not(:root) {
    ========================================================================== */
 
 /**
- * 1. Change the font styles in all browsers (opinionated).
- * 2. Remove the margin in Firefox and Safari.
+ * Remove the margin in Firefox and Safari.
  */
 
 button,
@@ -254,10 +233,7 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: sans-serif; /* 1 */
-  font-size: 100%; /* 1 */
-  line-height: 1.15; /* 1 */
-  margin: 0; /* 2 */
+  margin: 0;
 }
 
 /**
@@ -314,16 +290,6 @@ button:-moz-focusring,
 [type="reset"]:-moz-focusring,
 [type="submit"]:-moz-focusring {
   outline: 1px dotted ButtonText;
-}
-
-/**
- * Change the border, margin, and padding in all browsers (opinionated).
- */
-
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
 }
 
 /**

--- a/generic/_generic.reset.scss
+++ b/generic/_generic.reset.scss
@@ -51,3 +51,15 @@ fieldset {
   min-width: 0; /* [1] */
   border: 0;
 }
+
+/**
+ * Set the font-size for form elements to inherit from html.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font: inherit;
+}


### PR DESCRIPTION
As mentioned in #288.

We're currently inheriting some opinionated nastiness with v5.0.0, and should really upgrade to v6.0.0.

_However_ there is a catch. It appears we still need `font-size: 100%`, as we don't handle this inside inuit. (i'll highlight the line in the commit diff, but here is the rule:)

```scss
button,
input,
optgroup,
select,
textarea {
  font-size: 100%; 
  // [...] 
}
```

So we need to make a call about how we handle it. 
There's a discussion going on at https://github.com/necolas/normalize.css/issues/664 regarding opinionated styles. 

I think we should maybe add it to our `generic.reset` file? And perhaps even set it to `font: inherit;` instead of `font-size: 100%`.

Thoughts?