### PR TITLE
Update comment description

### DIFF
--- a/objects/_objects.flag.scss
+++ b/objects/_objects.flag.scss
@@ -49,6 +49,15 @@
 
     /**
      * 1. Fixes problem with images disappearing.
+     *    The > needs to remain in order for nested flag objects to not inherit 
+     *    their parent’s formatting. In case the image must be linked, try wrapping
+     *    the whole o-flag__img object into an anchor tag.
+     *    E.g.: 
+     *    <a href="/">
+     *      <div class="o-flag__img">
+     *        <img src="./link/to/image.jpg" alt="image alt text">
+     *      </div>
+     *    </a>
      */
 
     > img {

--- a/objects/_objects.flag.scss
+++ b/objects/_objects.flag.scss
@@ -50,8 +50,10 @@
     /**
      * 1. Fixes problem with images disappearing.
      *    The > needs to remain in order for nested flag objects to not inherit 
-     *    their parent’s formatting. In case the image must be linked, try wrapping
-     *    the whole o-flag__img object into an anchor tag.
+     *    their parent’s formatting. 
+     *    Hint: In case the image is wrapped into an anchor tag for linking reason,
+     *    it will disappear. In that case try wrapping the whole o-flag__img object 
+     *    into an anchor tag.
      *    E.g.: 
      *    <a href="/">
      *      <div class="o-flag__img">


### PR DESCRIPTION
Add a description clarifying the reason, why there has to be a direct child selector in the o-flag_img object and provide an example.