### PR TITLE
[refs #331] @elseif statement not valid in all sass compiler versions

### DIFF
--- a/tools/_tools.font-size.scss
+++ b/tools/_tools.font-size.scss
@@ -15,7 +15,7 @@
 
   @if ($important == true) {
     $important: !important;
-  } @elseif ($important == false) {
+  } @else if ($important == false) {
     $important: null;
   } @else {
     @error "`#{$important}` needs to be `true` or `false`."
@@ -35,7 +35,7 @@
       line-height: $line-height $important;
     }
 
-    @elseif ($line-height != "none" and $line-height != false) {
+    @else if ($line-height != 'none' and $line-height != false) {
       @error "D’oh! `#{$line-height}` is not a valid value for `$line-height`."
     }
 


### PR DESCRIPTION
After a brand new download of inuitcss and copying the files over to a /css directory in my project.  I was unable to get the scss file to transpile without first modifying the two @elseif occurrences in the _tools.font-size.scss file.

Having checked the documentation at [sass_reference](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#if__) it would appear that @elseif is not valid.

This should resolve #331 