### PR TITLE
[refs #328] Opt-out non-fluid imgs w/ `width`/`height` attr

### DIFF
--- a/elements/_elements.images.scss
+++ b/elements/_elements.images.scss
@@ -26,7 +26,7 @@ $inuit-static-images: true !default;
   @if ($inuit-static-images == true) {
 
   /**
-   * If a `width` and/or `height` attribute have been explicitly defined, let’s
+   * If a `width` and/or `height` attribute has been explicitly defined, let’s
    * not make the image fluid.
    */
 

--- a/elements/_elements.images.scss
+++ b/elements/_elements.images.scss
@@ -17,12 +17,22 @@ img {
 }
 
 
-/**
- * If a `width` and/or `height` attribute have been explicitly defined, let’s
- * not make the image fluid.
- */
+// In case you don't have control over generated `width` and `height` attributes
+// on `<img>` elements in your markup, but still want the images to be fluid,
+// set this to `false`.
 
-img[width],
-img[height] {
-  max-width: none;
+$inuit-static-images: true !default;
+
+  @if ($inuit-static-images == true) {
+
+  /**
+   * If a `width` and/or `height` attribute have been explicitly defined, let’s
+   * not make the image fluid.
+   */
+
+  img[width],
+  img[height] {
+    max-width: none;
+  }
+
 }


### PR DESCRIPTION
There are situations where you might not have any control over a CMS that generates markup for you, like in this case `width` and `height` attributes on your `<img>` elements.

In these cases, [inuitcss forces the `<img>`s to be non-fluid](https://github.com/inuitcss/inuitcss/blob/4469ab78f874ec9d3e54bca66168e4712c2e22eb/elements/_elements.images.scss?utf8=%E2%9C%93#L20-L28) which might not always be preferable.

By providing a way to opt-out of this behaviour, we take the effort from developers to build a solution themselves.

(see #328)