### PR TITLE
[refs #316] Reset push/pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Minor changes
 - Provide opt-out mechanism of static images when `width`/`height` attribute is assigned on `<img>`s. [[#328](https://github.com/inuitcss/inuitcss/issues/328)]
+- Provide possibility to reset push/pull. [[#316](https://github.com/inuitcss/inuitcss/issues/316)]
 
 
 

--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -126,6 +126,19 @@ $inuit-widths-breakpoint-separator: \@ !default;
 
   }
 
+  @if ($inuit-offsets == true) {
+
+    // Create auto push and pull classes.
+    .u-push-none#{$breakpoint} {
+      left: auto !important;
+    }
+
+    .u-pull-none#{$breakpoint} {
+      right: auto !important;
+    }
+
+  }
+
 }
 
 

--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -126,7 +126,7 @@ $inuit-widths-breakpoint-separator: \@ !default;
 
   }
 
-  @if ($inuit-offsets == true) {
+  @if ($inuit-offsets == true and $breakpoint != null) {
 
     // Create auto push and pull classes.
     .u-push-none#{$breakpoint} {

--- a/utilities/_utilities.widths.scss
+++ b/utilities/_utilities.widths.scss
@@ -132,6 +132,7 @@ $inuit-widths-breakpoint-separator: \@ !default;
   @if ($inuit-offsets == true and $breakpoint != null) {
 
     // Create auto push and pull classes.
+
     .u-push-none#{$breakpoint} {
       left: auto !important;
     }


### PR DESCRIPTION
#316 

Currently, there is no way to push/pull something on small screen and then reset that push/pull on larger screens. Adding breakpoint-dependent classes for resetting this eliminates the problem.