### PR TITLE
[refs #21] Fix minor typo in example.main.scss file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - Fix `$inuit-responsive-spacing-directions` documentation in `_utilities.responsive-spacings.scss`. [[#354](https://github.com/inuitcss/inuitcss/issues/354)]
+- Fix minor typo in `example.main.scss`.
 
 ## [6.0.0] - 2018-02-26
 

--- a/example.main.scss
+++ b/example.main.scss
@@ -146,7 +146,7 @@
 @import "utilities/utilities.clearfix";
 
 // Be aware that enabling offsets produces a large chunk of classes which might
-// bloat your CSS, depending of the amount of breakpoints you defined.
+// bloat your CSS, depending on the amount of breakpoints you defined.
 // Only set this to `true` if you are absolutely sure about what you are doing.
 $inuit-offsets: true;
 @import "utilities/utilities.widths";


### PR DESCRIPTION
Line 149: `bloat your CSS, depending of the amount of breakpoints you defined.`

This should read "depending on", rather than "depending of"