### PR TITLE
[refs #304] Fix ratio object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Fixes
+- Fix `o-ratio--img-contain` selector and centering. [[#304](https://github.com/inuitcss/inuitcss/issues/304)]
 - Fix `$inuit-responsive-spacing-directions` documentation in `_utilities.responsive-spacings.scss`. [[#354](https://github.com/inuitcss/inuitcss/issues/354)]
 - Fix minor typo in `example.main.scss`.
 

--- a/objects/_objects.ratio.scss
+++ b/objects/_objects.ratio.scss
@@ -54,6 +54,7 @@ $inuit-ratios: (
     top:    0;
     bottom: 0;
     left:   0;
+    right:  0;
     height: 100%;
     width:  100%;
   }

--- a/objects/_objects.ratio.scss
+++ b/objects/_objects.ratio.scss
@@ -106,7 +106,7 @@ $inuit-ratios: (
 
 .o-ratio--img-contain {
 
-  > .o-ratio__content:before {
+  > .o-ratio__content {
     height: auto;
     margin: auto;
     max-height: 100%;


### PR DESCRIPTION
Fix `o-ratio--img-contain` selector and centering

I think it would be nice to make a release then 😉.